### PR TITLE
Feedback -> Hide feedback on selection a new answer

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -912,6 +912,7 @@
                                 that.el.find('.show').removeAttr('disabled');
                                 that.showAnswerNotification.hide();
                                 that.submitAnswersAndSubmitButton();
+                                that.el.find('.wrapper-problem-response .message').hide();
                             });
                         }
                     });
@@ -930,6 +931,7 @@
                         that.saveNotification.hide();
                         that.showAnswerNotification.hide();
                         that.submitAnswersAndSubmitButton();
+                        that.el.find('.wrapper-problem-response .message').hide();
                     });
                 }
             });


### PR DESCRIPTION
### Hide feedback on selection a new answer

![image](https://user-images.githubusercontent.com/51116673/161786045-c9b0545f-93ab-4b67-99bd-f0d0dba85ae5.png)
Feedback is not cleared when a new answer is selected, which pushes the submit button off the page in many cases