### PR TITLE
Courses reset user score issue (Underscore.js and Lodash script conflict) - resolved

### DIFF
--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -28,6 +28,7 @@ var StaffDebug = (function() {
     };
 
     var doInstructorDashAction = function(action) {
+        checkDashVariableScope();
         var user = getUser(action.locationName);
         var pdata = {
             problem_to_reset: action.location,
@@ -201,4 +202,24 @@ $(document).ready(function() {
         );
         return false;
     });
+});
+
+// For checking is the variable '_' loaded by Underscore or Lodash
+let checkDashVariableScope = (function (){
+  var isLodash = false;
+  // If _ is defined and the function _.forEach exists then we know underscore OR lodash are in place
+  if ( 'undefined' != typeof(_) && 'function' == typeof(_.forEach) ) {
+    // A small sample of some of the functions that exist in lodash but not underscore
+    var funcs = [ 'now', 'before', 'negate' ];
+    // Simplest if assume exists to start
+    isLodash  = true;
+    funcs.forEach( function ( func ) {
+      // If just one of the functions do not exist, then not lodash
+      isLodash = ('function' != typeof(_[ func ])) ? false : isLodash;
+    } );
+  }
+  if ( ! isLodash ) {
+    // We know that underscore is loaded in the _ variable, we'll reload Lodash in it.
+    window.lodash = _.noConflict();
+  }
 });


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
